### PR TITLE
Make axiom_session:delete work with axiom_session_ets

### DIFF
--- a/src/axiom_session.erl
+++ b/src/axiom_session.erl
@@ -58,7 +58,7 @@ get(Key, Req) ->
 %% @doc Deletes a session.
 -spec delete(#http_req{}) -> any().
 delete(Req) ->
-	gen_server:call(?MODULE, {reset, [Req]}).
+	gen_server:call(?MODULE, {delete, [Req]}).
 
 
 %% CALLBACKS


### PR DESCRIPTION
axiom_session exports delete/1, as does axiom_session_ets.
However, when axiom_session:delete is called, it sends
the "reset" message, which results in a call to the
(undefined) function axiom_session_ets:reset.
Changed the message from "reset" to "delete" to conform
to what appears to be a convention.
