### PR TITLE
Fix relative redirects

### DIFF
--- a/src/axiom.erl
+++ b/src/axiom.erl
@@ -118,7 +118,7 @@ redirect(UrlOrPath, Req) ->
 					_ -> <<>>
 				end,
 				<<"://">>,
-				Req#http_req.host,
+				join(Req#http_req.host, <<".">>),
 				case Req#http_req.port of
 					80 -> <<>>;
 					Port -> [<<":">>, integer_to_list(Port)]
@@ -368,4 +368,12 @@ stream_loop(Req) ->
 			stream_loop(Req)
 	end.
 
-
+%% @private
+-spec join([binary()], binary()) -> binary().
+join([], _Sep) ->
+	[];
+join([Bin], _Sep) ->
+	Bin;
+join([Bin|Bins], Sep) ->
+	Rest = join(Bins, Sep),
+	<<Bin/binary, Sep/binary, Rest/binary>>.


### PR DESCRIPTION
Cowboy 0.6.1 stores the request host as a list of binaries, not as
a single binary or string, as Axiom has previously assumed.
This broke relative redirects when the host field was injected
as-is into the absolute redirect url ("." were omitted, so
if the host was "example.com" the redirect went to "examplecom"
due to iolist sematics).

Fixed relative redirects and added/fixed some test cases.
